### PR TITLE
Analyze and suggest settings page improvements

### DIFF
--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -11,12 +11,14 @@ import { authApi, RegisterRequest, type Department } from "@/lib/api"
 import { useAuth } from "@/lib/auth-context"
 import { useAppContext } from "@/lib/app-context"
 import { toast } from "sonner"
+import { UserX } from "lucide-react"
 
 export default function RegisterPage() {
   const { register } = useAuth()
   const { Alert } = useAppContext()
   const [loading, setLoading] = useState(false)
   const [departments, setDepartments] = useState<Department[]>([])
+  const [allowRegistration, setAllowRegistration] = useState(true)
   const [formData, setFormData] = useState<RegisterRequest>({
     name: "",
     email: "",
@@ -25,20 +27,37 @@ export default function RegisterPage() {
     department_id: 0,
   })
 
+  // 检查是否允许注册
+  useEffect(() => {
+    const checkRegistrationSettings = () => {
+      try {
+        const savedSetting = localStorage.getItem("allowRegistration")
+        if (savedSetting !== null) {
+          setAllowRegistration(JSON.parse(savedSetting))
+        }
+      } catch (error) {
+        console.error("获取注册设置失败:", error)
+      }
+    }
+    checkRegistrationSettings()
+  }, [])
+
   // 加载部门列表
   useEffect(() => {
     const fetchDepartments = async () => {
       try {
         const response = await authApi.getDepartments()
-        setFormData(prev => ({ ...prev, department_id: response.data[0].id }))
+        setFormData(prev => ({ ...prev, department_id: response.data[0]?.id || 0 }))
         setDepartments(response.data)
       } catch (error) {
         console.error("获取部门列表失败:", error)
         await Alert("错误", "获取部门列表失败")
       }
     }
-    fetchDepartments()
-  }, [Alert])
+    if (allowRegistration) {
+      fetchDepartments()
+    }
+  }, [Alert, allowRegistration])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -86,94 +105,122 @@ export default function RegisterPage() {
       <div className="w-full max-w-sm py-10">
         <div className="text-center mb-6">
           <h1 className="text-2xl font-bold text-gray-900">绩效管理系统</h1>
-          <p className="text-gray-600 mt-2">创建新账户</p>
+          <p className="text-gray-600 mt-2">
+            {allowRegistration ? "创建新账户" : "用户注册"}
+          </p>
         </div>
 
         <Card>
           <CardHeader>
-            <CardTitle>注册账户</CardTitle>
-            <CardDescription>请填写以下信息创建您的账户</CardDescription>
+            <CardTitle className="flex items-center">
+              {!allowRegistration && <UserX className="w-5 h-5 mr-2 text-red-500" />}
+              {allowRegistration ? "注册账户" : "注册暂不开放"}
+            </CardTitle>
+            <CardDescription>
+              {allowRegistration 
+                ? "请填写以下信息创建您的账户"
+                : "系统管理员已关闭用户注册功能"
+              }
+            </CardDescription>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleSubmit}>
-              <div className="flex flex-col gap-6">
-                <div className="grid gap-3">
-                  <Label htmlFor="name">姓名</Label>
-                  <Input
-                    id="name"
-                    name="name"
-                    type="text"
-                    placeholder="请输入姓名"
-                    value={formData.name}
-                    onChange={handleChange}
-                    required
-                  />
+            {allowRegistration ? (
+              <form onSubmit={handleSubmit}>
+                <div className="flex flex-col gap-6">
+                  <div className="grid gap-3">
+                    <Label htmlFor="name">姓名</Label>
+                    <Input
+                      id="name"
+                      name="name"
+                      type="text"
+                      placeholder="请输入姓名"
+                      value={formData.name}
+                      onChange={handleChange}
+                      required
+                    />
+                  </div>
+                  <div className="grid gap-3">
+                    <Label htmlFor="email">邮箱</Label>
+                    <Input
+                      id="email"
+                      name="email"
+                      type="email"
+                      placeholder="请输入邮箱"
+                      value={formData.email}
+                      onChange={handleChange}
+                      required
+                    />
+                  </div>
+                  <div className="grid gap-3">
+                    <Label htmlFor="password">密码</Label>
+                    <Input
+                      id="password"
+                      name="password"
+                      type="password"
+                      placeholder="请输入密码（至少6位）"
+                      value={formData.password}
+                      onChange={handleChange}
+                      minLength={6}
+                      required
+                    />
+                  </div>
+                  <div className="grid gap-3">
+                    <Label htmlFor="position">职位</Label>
+                    <Input
+                      id="position"
+                      name="position"
+                      type="text"
+                      placeholder="请输入职位"
+                      value={formData.position}
+                      onChange={handleChange}
+                      required
+                    />
+                  </div>
+                  <div className="grid gap-3">
+                    <Label htmlFor="department">部门</Label>
+                    <Select value={formData.department_id.toString()} onValueChange={handleDepartmentChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="请选择部门" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {departments.map(dept => (
+                          <SelectItem key={dept.id} value={dept.id.toString()}>
+                            {dept.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex flex-col gap-3">
+                    <Button type="submit" className="w-full" disabled={loading}>
+                      {loading ? "注册中..." : "注册"}
+                    </Button>
+                  </div>
                 </div>
-                <div className="grid gap-3">
-                  <Label htmlFor="email">邮箱</Label>
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    placeholder="请输入邮箱"
-                    value={formData.email}
-                    onChange={handleChange}
-                    required
-                  />
+                <div className="mt-4 text-center text-sm">
+                  已有账户？{" "}
+                  <Link href="/auth/login" className="underline underline-offset-4 hover:text-blue-600">
+                    立即登录
+                  </Link>
                 </div>
-                <div className="grid gap-3">
-                  <Label htmlFor="password">密码</Label>
-                  <Input
-                    id="password"
-                    name="password"
-                    type="password"
-                    placeholder="请输入密码（至少6位）"
-                    value={formData.password}
-                    onChange={handleChange}
-                    minLength={6}
-                    required
-                  />
-                </div>
-                <div className="grid gap-3">
-                  <Label htmlFor="position">职位</Label>
-                  <Input
-                    id="position"
-                    name="position"
-                    type="text"
-                    placeholder="请输入职位"
-                    value={formData.position}
-                    onChange={handleChange}
-                    required
-                  />
-                </div>
-                <div className="grid gap-3">
-                  <Label htmlFor="department">部门</Label>
-                  <Select value={formData.department_id.toString()} onValueChange={handleDepartmentChange}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="请选择部门" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {departments.map(dept => (
-                        <SelectItem key={dept.id} value={dept.id.toString()}>
-                          {dept.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="flex flex-col gap-3">
-                  <Button type="submit" className="w-full" disabled={loading}>
-                    {loading ? "注册中..." : "注册"}
+              </form>
+            ) : (
+              <div className="text-center py-8">
+                <div className="space-y-4">
+                  <div className="text-gray-600">
+                    当前系统暂不开放用户注册功能。
+                  </div>
+                  <div className="text-sm text-gray-500">
+                    如需创建账户，请联系系统管理员。
+                  </div>
+                  <Button asChild className="w-full">
+                    <Link href="/auth/login">
+                      返回登录
+                    </Link>
                   </Button>
                 </div>
               </div>
-              <div className="mt-4 text-center text-sm">
-                已有账户？{" "}
-                <Link href="/auth/login" className="underline underline-offset-4 hover:text-blue-600">
-                  立即登录
-                </Link>
-              </div>
-            </form>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { authApi, RegisterRequest, type Department } from "@/lib/api"
+import { authApi, RegisterRequest, type Department, settingsApi } from "@/lib/api"
 import { useAuth } from "@/lib/auth-context"
 import { useAppContext } from "@/lib/app-context"
 import { toast } from "sonner"
@@ -29,14 +29,14 @@ export default function RegisterPage() {
 
   // 检查是否允许注册
   useEffect(() => {
-    const checkRegistrationSettings = () => {
+    const checkRegistrationSettings = async () => {
       try {
-        const savedSetting = localStorage.getItem("allowRegistration")
-        if (savedSetting !== null) {
-          setAllowRegistration(JSON.parse(savedSetting))
-        }
+        const response = await settingsApi.get()
+        setAllowRegistration(response.data.allow_registration)
       } catch (error) {
         console.error("获取注册设置失败:", error)
+        // 如果获取失败，默认允许注册
+        setAllowRegistration(true)
       }
     }
     checkRegistrationSettings()

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,81 +1,49 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Label } from "@/components/ui/label"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import {
   Settings,
-  Shield,
-  Database,
-  Bell,
-  Key,
-  Download,
-  Upload,
-  Trash2,
   RefreshCw,
   CheckCircle,
   AlertCircle,
+  LogOut,
 } from "lucide-react"
-import { type SystemSettings, type Message } from "@/lib/api"
+import { useAuth } from "@/lib/auth-context"
 import { useAppContext } from "@/lib/app-context"
 
 export default function SettingsPage() {
+  const { logout } = useAuth()
   const { Confirm } = useAppContext()
-  const [settings, setSettings] = useState<SystemSettings>({
-    // 系统设置
-    system_name: "DooTask KPI 绩效管理系统",
-    system_version: "1.0.0",
-    company_name: "示例公司",
-    company_logo: "",
-    timezone: "Asia/Shanghai",
-    language: "zh-CN",
-    date_format: "YYYY-MM-DD",
-
-    // 评估设置
-    evaluation_auto_create: true,
-    evaluation_reminder_days: 3,
-    evaluation_timeout_days: 7,
-    allow_self_evaluation: true,
-    require_manager_approval: true,
-    require_hr_approval: true,
-    allow_evaluation_comments: true,
-
-    // 通知设置
-    notification_enabled: true,
-    email_notifications: true,
-    system_notifications: true,
-    reminder_notifications: true,
-
-    // 安全设置
-    password_min_length: 8,
-    password_require_uppercase: true,
-    password_require_lowercase: true,
-    password_require_numbers: true,
-    password_require_symbols: false,
-    session_timeout: 30,
-    max_login_attempts: 5,
-
-    // 数据设置
-    data_retention_months: 24,
-    backup_enabled: true,
-    backup_frequency: "daily",
-    export_format: "xlsx",
-  })
-
+  const [allowRegistration, setAllowRegistration] = useState(true)
   const [loading, setLoading] = useState(false)
-  const [message, setMessage] = useState<Message>({ type: "", content: "" })
+  const [message, setMessage] = useState<{ type: string; content: string }>({ type: "", content: "" })
+
+  // 初始化设置状态
+  useEffect(() => {
+    const initializeSettings = () => {
+      try {
+        const savedSetting = localStorage.getItem("allowRegistration")
+        if (savedSetting !== null) {
+          setAllowRegistration(JSON.parse(savedSetting))
+        }
+      } catch (error) {
+        console.error("获取设置失败:", error)
+      }
+    }
+    initializeSettings()
+  }, [])
 
   // 保存设置
   const handleSaveSettings = async () => {
     setLoading(true)
     try {
-      // 模拟保存设置
+      // 模拟保存设置到本地存储
+      localStorage.setItem("allowRegistration", JSON.stringify(allowRegistration))
       await new Promise(resolve => setTimeout(resolve, 1000))
       setMessage({ type: "success", content: "设置保存成功！" })
       setTimeout(() => setMessage({ type: "", content: "" }), 3000)
@@ -86,106 +54,11 @@ export default function SettingsPage() {
     }
   }
 
-  // 重置设置
-  const handleResetSettings = async () => {
-    const result = await Confirm("重置设置", "确定要重置所有设置吗？这将恢复系统默认配置。")
+  // 退出登录
+  const handleLogout = async () => {
+    const result = await Confirm("退出登录", "确定要退出当前账户吗？")
     if (result) {
-      setSettings({
-        system_name: "DooTask KPI 绩效管理系统",
-        system_version: "1.0.0",
-        company_name: "示例公司",
-        company_logo: "",
-        timezone: "Asia/Shanghai",
-        language: "zh-CN",
-        date_format: "YYYY-MM-DD",
-        evaluation_auto_create: true,
-        evaluation_reminder_days: 3,
-        evaluation_timeout_days: 7,
-        allow_self_evaluation: true,
-        require_manager_approval: true,
-        require_hr_approval: true,
-        allow_evaluation_comments: true,
-        notification_enabled: true,
-        email_notifications: true,
-        system_notifications: true,
-        reminder_notifications: true,
-        password_min_length: 8,
-        password_require_uppercase: true,
-        password_require_lowercase: true,
-        password_require_numbers: true,
-        password_require_symbols: false,
-        session_timeout: 30,
-        max_login_attempts: 5,
-        data_retention_months: 24,
-        backup_enabled: true,
-        backup_frequency: "daily",
-        export_format: "xlsx",
-      })
-      setMessage({ type: "success", content: "设置已重置为默认值。" })
-    }
-  }
-
-  // 导出配置
-  const handleExportConfig = () => {
-    const configData = JSON.stringify(settings, null, 2)
-    const blob = new Blob([configData], { type: "application/json" })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement("a")
-    a.href = url
-    a.download = "kpi-system-config.json"
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-    setMessage({ type: "success", content: "配置文件已导出。" })
-  }
-
-  // 导入配置
-  const handleImportConfig = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (file) {
-      const reader = new FileReader()
-      reader.onload = e => {
-        try {
-          const importedSettings = JSON.parse(e.target?.result as string)
-          setSettings({ ...settings, ...importedSettings })
-          setMessage({ type: "success", content: "配置文件导入成功。" })
-        } catch {
-          setMessage({ type: "error", content: "配置文件格式错误。" })
-        }
-      }
-      reader.readAsText(file)
-    }
-  }
-
-  // 数据库备份
-  const handleBackupDatabase = async () => {
-    setLoading(true)
-    try {
-      // 模拟备份操作
-      await new Promise(resolve => setTimeout(resolve, 2000))
-      setMessage({ type: "success", content: "数据库备份完成。" })
-    } catch {
-      setMessage({ type: "error", content: "备份失败，请重试。" })
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  // 清理数据
-  const handleCleanupData = async () => {
-    const result = await Confirm("清理数据", "确定要清理过期数据吗？此操作无法撤销。")
-    if (result) {
-      setLoading(true)
-      try {
-        // 模拟清理操作
-        await new Promise(resolve => setTimeout(resolve, 1500))
-        setMessage({ type: "success", content: "数据清理完成。" })
-      } catch {
-        setMessage({ type: "error", content: "数据清理失败。" })
-      } finally {
-        setLoading(false)
-      }
+      logout()
     }
   }
 
@@ -194,12 +67,12 @@ export default function SettingsPage() {
       <div className="flex justify-between items-center flex-wrap gap-4">
         <div>
           <h1 className="text-3xl font-bold text-gray-900">系统设置</h1>
-          <p className="text-gray-600 mt-2">管理系统配置和参数</p>
+          <p className="text-gray-600 mt-2">管理系统基本配置</p>
         </div>
         <div className="flex items-center space-x-2">
-          <Button variant="outline" onClick={handleResetSettings}>
-            <RefreshCw className="w-4 h-4 mr-2" />
-            重置设置
+          <Button variant="outline" onClick={handleLogout} className="text-red-600 hover:text-red-700">
+            <LogOut className="w-4 h-4 mr-2" />
+            退出登录
           </Button>
           <Button onClick={handleSaveSettings} disabled={loading}>
             {loading ? <RefreshCw className="w-4 h-4 mr-2 animate-spin" /> : <CheckCircle className="w-4 h-4 mr-2" />}
@@ -216,421 +89,41 @@ export default function SettingsPage() {
         </Alert>
       )}
 
-      <Tabs defaultValue="general" className="space-y-4">
-        <TabsList className="grid w-full grid-cols-5">
-          <TabsTrigger value="general">基本设置</TabsTrigger>
-          <TabsTrigger value="evaluation">评估设置</TabsTrigger>
-          <TabsTrigger value="notification">通知设置</TabsTrigger>
-          <TabsTrigger value="security">安全设置</TabsTrigger>
-          <TabsTrigger value="data">数据管理</TabsTrigger>
-        </TabsList>
+      {/* 系统设置 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Settings className="w-5 h-5 mr-2" />
+            系统设置
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+            <div className="flex-1">
+              <Label htmlFor="allow_registration" className="text-sm font-medium">
+                允许用户注册
+              </Label>
+              <p className="text-sm text-gray-600 mt-1">
+                开启后，新用户可以自行注册账户；关闭后，只能由管理员创建账户。
+              </p>
+            </div>
+            <Switch
+              id="allow_registration"
+              checked={allowRegistration}
+              onCheckedChange={setAllowRegistration}
+            />
+          </div>
 
-        {/* 基本设置 */}
-        <TabsContent value="general" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center">
-                <Settings className="w-5 h-5 mr-2" />
-                系统基本信息
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="system_name">系统名称</Label>
-                  <Input
-                    id="system_name"
-                    value={settings.system_name}
-                    onChange={e => setSettings({ ...settings, system_name: e.target.value })}
-                  />
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="system_version">系统版本</Label>
-                  <Input id="system_version" value={settings.system_version} disabled />
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="company_name">公司名称</Label>
-                  <Input
-                    id="company_name"
-                    value={settings.company_name}
-                    onChange={e => setSettings({ ...settings, company_name: e.target.value })}
-                  />
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="company_logo">公司Logo URL</Label>
-                  <Input
-                    id="company_logo"
-                    value={settings.company_logo}
-                    onChange={e => setSettings({ ...settings, company_logo: e.target.value })}
-                    placeholder="https://example.com/logo.png"
-                  />
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="timezone">时区</Label>
-                  <Select
-                    value={settings.timezone}
-                    onValueChange={value => setSettings({ ...settings, timezone: value })}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="Asia/Shanghai">Asia/Shanghai (UTC+8)</SelectItem>
-                      <SelectItem value="Asia/Tokyo">Asia/Tokyo (UTC+9)</SelectItem>
-                      <SelectItem value="UTC">UTC (UTC+0)</SelectItem>
-                      <SelectItem value="America/New_York">America/New_York (UTC-5)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="language">语言</Label>
-                  <Select
-                    value={settings.language}
-                    onValueChange={value => setSettings({ ...settings, language: value })}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="zh-CN">中文（简体）</SelectItem>
-                      <SelectItem value="zh-TW">中文（繁体）</SelectItem>
-                      <SelectItem value="en-US">English</SelectItem>
-                      <SelectItem value="ja-JP">日本語</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* 评估设置 */}
-        <TabsContent value="evaluation" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center">
-                <Shield className="w-5 h-5 mr-2" />
-                评估流程设置
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="evaluation_auto_create">自动创建评估</Label>
-                  <Switch
-                    id="evaluation_auto_create"
-                    checked={settings.evaluation_auto_create}
-                    onCheckedChange={checked => setSettings({ ...settings, evaluation_auto_create: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="allow_self_evaluation">允许员工自评</Label>
-                  <Switch
-                    id="allow_self_evaluation"
-                    checked={settings.allow_self_evaluation}
-                    onCheckedChange={checked => setSettings({ ...settings, allow_self_evaluation: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="require_manager_approval">需要主管审批</Label>
-                  <Switch
-                    id="require_manager_approval"
-                    checked={settings.require_manager_approval}
-                    onCheckedChange={checked => setSettings({ ...settings, require_manager_approval: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="require_hr_approval">需要HR审批</Label>
-                  <Switch
-                    id="require_hr_approval"
-                    checked={settings.require_hr_approval}
-                    onCheckedChange={checked => setSettings({ ...settings, require_hr_approval: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="allow_evaluation_comments">允许评估备注</Label>
-                  <Switch
-                    id="allow_evaluation_comments"
-                    checked={settings.allow_evaluation_comments}
-                    onCheckedChange={checked => setSettings({ ...settings, allow_evaluation_comments: checked })}
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="evaluation_reminder_days">评估提醒天数</Label>
-                  <Input
-                    id="evaluation_reminder_days"
-                    type="number"
-                    value={settings.evaluation_reminder_days}
-                    onChange={e => setSettings({ ...settings, evaluation_reminder_days: parseInt(e.target.value) })}
-                    min="1"
-                    max="30"
-                  />
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="evaluation_timeout_days">评估超时天数</Label>
-                  <Input
-                    id="evaluation_timeout_days"
-                    type="number"
-                    value={settings.evaluation_timeout_days}
-                    onChange={e => setSettings({ ...settings, evaluation_timeout_days: parseInt(e.target.value) })}
-                    min="1"
-                    max="90"
-                  />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* 通知设置 */}
-        <TabsContent value="notification" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center">
-                <Bell className="w-5 h-5 mr-2" />
-                通知设置
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="notification_enabled">启用通知</Label>
-                  <Switch
-                    id="notification_enabled"
-                    checked={settings.notification_enabled}
-                    onCheckedChange={checked => setSettings({ ...settings, notification_enabled: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="email_notifications">邮件通知</Label>
-                  <Switch
-                    id="email_notifications"
-                    checked={settings.email_notifications}
-                    onCheckedChange={checked => setSettings({ ...settings, email_notifications: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="system_notifications">系统通知</Label>
-                  <Switch
-                    id="system_notifications"
-                    checked={settings.system_notifications}
-                    onCheckedChange={checked => setSettings({ ...settings, system_notifications: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="reminder_notifications">提醒通知</Label>
-                  <Switch
-                    id="reminder_notifications"
-                    checked={settings.reminder_notifications}
-                    onCheckedChange={checked => setSettings({ ...settings, reminder_notifications: checked })}
-                  />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* 安全设置 */}
-        <TabsContent value="security" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center">
-                <Key className="w-5 h-5 mr-2" />
-                密码策略
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="password_min_length">最小密码长度</Label>
-                  <Input
-                    id="password_min_length"
-                    type="number"
-                    value={settings.password_min_length}
-                    onChange={e => setSettings({ ...settings, password_min_length: parseInt(e.target.value) })}
-                    min="6"
-                    max="32"
-                  />
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="session_timeout">会话超时（分钟）</Label>
-                  <Input
-                    id="session_timeout"
-                    type="number"
-                    value={settings.session_timeout}
-                    onChange={e => setSettings({ ...settings, session_timeout: parseInt(e.target.value) })}
-                    min="5"
-                    max="480"
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="password_require_uppercase">需要大写字母</Label>
-                  <Switch
-                    id="password_require_uppercase"
-                    checked={settings.password_require_uppercase}
-                    onCheckedChange={checked => setSettings({ ...settings, password_require_uppercase: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="password_require_lowercase">需要小写字母</Label>
-                  <Switch
-                    id="password_require_lowercase"
-                    checked={settings.password_require_lowercase}
-                    onCheckedChange={checked => setSettings({ ...settings, password_require_lowercase: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="password_require_numbers">需要数字</Label>
-                  <Switch
-                    id="password_require_numbers"
-                    checked={settings.password_require_numbers}
-                    onCheckedChange={checked => setSettings({ ...settings, password_require_numbers: checked })}
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="password_require_symbols">需要特殊字符</Label>
-                  <Switch
-                    id="password_require_symbols"
-                    checked={settings.password_require_symbols}
-                    onCheckedChange={checked => setSettings({ ...settings, password_require_symbols: checked })}
-                  />
-                </div>
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="max_login_attempts">最大登录尝试次数</Label>
-                <Input
-                  id="max_login_attempts"
-                  type="number"
-                  value={settings.max_login_attempts}
-                  onChange={e => setSettings({ ...settings, max_login_attempts: parseInt(e.target.value) })}
-                  min="3"
-                  max="10"
-                />
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* 数据管理 */}
-        <TabsContent value="data" className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center">
-                <Database className="w-5 h-5 mr-2" />
-                数据管理
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="data_retention_months">数据保留时间（月）</Label>
-                  <Input
-                    id="data_retention_months"
-                    type="number"
-                    value={settings.data_retention_months}
-                    onChange={e => setSettings({ ...settings, data_retention_months: parseInt(e.target.value) })}
-                    min="1"
-                    max="120"
-                  />
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="export_format">导出格式</Label>
-                  <Select
-                    value={settings.export_format}
-                    onValueChange={value => setSettings({ ...settings, export_format: value })}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="xlsx">Excel (.xlsx)</SelectItem>
-                      <SelectItem value="csv">CSV (.csv)</SelectItem>
-                      <SelectItem value="pdf">PDF (.pdf)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="backup_enabled">启用自动备份</Label>
-                  <Switch
-                    id="backup_enabled"
-                    checked={settings.backup_enabled}
-                    onCheckedChange={checked => setSettings({ ...settings, backup_enabled: checked })}
-                  />
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label htmlFor="backup_frequency">备份频率</Label>
-                  <Select
-                    value={settings.backup_frequency}
-                    onValueChange={value => setSettings({ ...settings, backup_frequency: value })}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="daily">每天</SelectItem>
-                      <SelectItem value="weekly">每周</SelectItem>
-                      <SelectItem value="monthly">每月</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>数据操作</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label>配置管理</Label>
-                  <div className="flex space-x-2">
-                    <Button variant="outline" size="sm" onClick={handleExportConfig}>
-                      <Download className="w-4 h-4 mr-1" />
-                      导出配置
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => document.getElementById("config-import")?.click()}
-                    >
-                      <Upload className="w-4 h-4 mr-1" />
-                      导入配置
-                    </Button>
-                    <input
-                      id="config-import"
-                      type="file"
-                      accept=".json"
-                      onChange={handleImportConfig}
-                      className="hidden"
-                    />
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <Label>数据库操作</Label>
-                  <div className="flex space-x-2">
-                    <Button variant="outline" size="sm" onClick={handleBackupDatabase} disabled={loading}>
-                      <Database className="w-4 h-4 mr-1" />
-                      立即备份
-                    </Button>
-                    <Button variant="outline" size="sm" onClick={handleCleanupData} disabled={loading}>
-                      <Trash2 className="w-4 h-4 mr-1" />
-                      清理数据
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
-      </Tabs>
+          <div className="p-4 bg-blue-50 rounded-lg">
+            <h3 className="text-sm font-medium text-blue-900 mb-2">功能说明</h3>
+            <ul className="text-sm text-blue-800 space-y-1">
+              <li>• 开启注册：用户可以通过注册页面创建新账户</li>
+              <li>• 关闭注册：注册页面将显示"暂不开放注册"的提示</li>
+              <li>• 退出登录：点击右上角的"退出登录"按钮安全退出系统</li>
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react"
 import { useAuth } from "@/lib/auth-context"
 import { useAppContext } from "@/lib/app-context"
+import { settingsApi } from "@/lib/api"
 
 export default function SettingsPage() {
   const { logout } = useAuth()
@@ -25,29 +26,32 @@ export default function SettingsPage() {
 
   // 初始化设置状态
   useEffect(() => {
-    const initializeSettings = () => {
+    const fetchSettings = async () => {
       try {
-        const savedSetting = localStorage.getItem("allowRegistration")
-        if (savedSetting !== null) {
-          setAllowRegistration(JSON.parse(savedSetting))
-        }
+        setLoading(true)
+        const response = await settingsApi.get()
+        setAllowRegistration(response.data.allow_registration)
       } catch (error) {
         console.error("获取设置失败:", error)
+        setMessage({ type: "error", content: "获取设置失败" })
+      } finally {
+        setLoading(false)
       }
     }
-    initializeSettings()
+    fetchSettings()
   }, [])
 
   // 保存设置
   const handleSaveSettings = async () => {
     setLoading(true)
     try {
-      // 模拟保存设置到本地存储
-      localStorage.setItem("allowRegistration", JSON.stringify(allowRegistration))
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      setMessage({ type: "success", content: "设置保存成功！" })
+      const response = await settingsApi.update({
+        allow_registration: allowRegistration,
+      })
+      setMessage({ type: "success", content: response.message || "设置保存成功！" })
       setTimeout(() => setMessage({ type: "", content: "" }), 3000)
-    } catch {
+    } catch (error) {
+      console.error("保存设置失败:", error)
       setMessage({ type: "error", content: "保存设置失败，请重试。" })
     } finally {
       setLoading(false)

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -181,43 +181,7 @@ export interface ExportResponse {
 
 // 设置相关接口
 export interface SystemSettings {
-  system_name: string
-  system_version: string
-  company_name: string
-  company_logo: string
-  timezone: string
-  language: string
-  date_format: string
-
-  // 评估设置
-  evaluation_auto_create: boolean
-  evaluation_reminder_days: number
-  evaluation_timeout_days: number
-  allow_self_evaluation: boolean
-  require_manager_approval: boolean
-  require_hr_approval: boolean
-  allow_evaluation_comments: boolean
-
-  // 通知设置
-  notification_enabled: boolean
-  email_notifications: boolean
-  system_notifications: boolean
-  reminder_notifications: boolean
-
-  // 安全设置
-  password_min_length: number
-  password_require_uppercase: boolean
-  password_require_lowercase: boolean
-  password_require_numbers: boolean
-  password_require_symbols: boolean
-  session_timeout: number
-  max_login_attempts: number
-
-  // 数据设置
-  data_retention_months: number
-  backup_enabled: boolean
-  backup_frequency: string
-  export_format: string
+  allow_registration: boolean
 }
 
 // 消息类型
@@ -435,6 +399,15 @@ export const authApi = {
     const userInfo = localStorage.getItem("user_info")
     return userInfo ? JSON.parse(userInfo) : null
   },
+}
+
+// 系统设置API
+export const settingsApi = {
+  // 获取系统设置
+  get: (): Promise<{ data: SystemSettings }> => api.get("/settings"),
+  
+  // 更新系统设置
+  update: (data: SystemSettings): Promise<{ data: SystemSettings; message: string }> => api.put("/settings", data),
 }
 
 export default api

--- a/server/go.mod
+++ b/server/go.mod
@@ -7,7 +7,9 @@ toolchain go1.23.11
 require (
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.9.1
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/xuri/excelize/v2 v2.9.1
+	golang.org/x/crypto v0.38.0
 	gorm.io/driver/sqlite v1.5.4
 	gorm.io/gorm v1.25.5
 )
@@ -21,7 +23,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -40,7 +41,6 @@ require (
 	github.com/xuri/efp v0.0.1 // indirect
 	github.com/xuri/nfp v0.0.1 // indirect
 	golang.org/x/arch v0.3.0 // indirect
-	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect

--- a/server/handlers/auth.go
+++ b/server/handlers/auth.go
@@ -87,6 +87,15 @@ func Register(c *gin.Context) {
 		return
 	}
 
+	// 检查是否允许注册
+	var allowRegistrationSetting models.SystemSetting
+	if err := models.DB.Where("key = ?", "allow_registration").First(&allowRegistrationSetting).Error; err == nil {
+		if allowRegistrationSetting.Value != "true" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "系统当前不允许用户注册"})
+			return
+		}
+	}
+
 	// 检查邮箱是否已存在
 	var existingUser models.Employee
 	if err := models.DB.Where("email = ?", req.Email).First(&existingUser).Error; err == nil {

--- a/server/handlers/settings.go
+++ b/server/handlers/settings.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"dootask-kpi-server/models"
+)
+
+// 系统设置响应结构
+type SystemSettingsResponse struct {
+	AllowRegistration bool `json:"allow_registration"`
+}
+
+// 设置更新请求结构
+type UpdateSettingsRequest struct {
+	AllowRegistration bool `json:"allow_registration"`
+}
+
+// 获取系统设置
+func GetSystemSettings(c *gin.Context) {
+	var settings SystemSettingsResponse
+	
+	// 获取注册设置
+	var allowRegistrationSetting models.SystemSetting
+	if err := models.DB.Where("key = ?", "allow_registration").First(&allowRegistrationSetting).Error; err == nil {
+		settings.AllowRegistration = allowRegistrationSetting.Value == "true"
+	} else {
+		// 如果设置不存在，默认为true
+		settings.AllowRegistration = true
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data": settings,
+	})
+}
+
+// 更新系统设置
+func UpdateSystemSettings(c *gin.Context) {
+	var req UpdateSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// 更新注册设置
+	allowRegistrationValue := strconv.FormatBool(req.AllowRegistration)
+	var allowRegistrationSetting models.SystemSetting
+	
+	// 先查找是否存在
+	if err := models.DB.Where("key = ?", "allow_registration").First(&allowRegistrationSetting).Error; err != nil {
+		// 如果不存在，创建新的设置
+		allowRegistrationSetting = models.SystemSetting{
+			Key:   "allow_registration",
+			Value: allowRegistrationValue,
+			Type:  "boolean",
+		}
+		if err := models.DB.Create(&allowRegistrationSetting).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "创建设置失败"})
+			return
+		}
+	} else {
+		// 如果存在，更新值
+		allowRegistrationSetting.Value = allowRegistrationValue
+		if err := models.DB.Save(&allowRegistrationSetting).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "更新设置失败"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "设置更新成功",
+		"data": SystemSettingsResponse{
+			AllowRegistration: req.AllowRegistration,
+		},
+	})
+}
+
+// 获取单个设置项（供其他组件使用）
+func GetSetting(key string) (string, error) {
+	var setting models.SystemSetting
+	if err := models.DB.Where("key = ?", key).First(&setting).Error; err != nil {
+		return "", err
+	}
+	return setting.Value, nil
+}
+
+// 设置单个设置项（供其他组件使用）
+func SetSetting(key, value, settingType string) error {
+	var setting models.SystemSetting
+	
+	// 先查找是否存在
+	if err := models.DB.Where("key = ?", key).First(&setting).Error; err != nil {
+		// 如果不存在，创建新的设置
+		setting = models.SystemSetting{
+			Key:   key,
+			Value: value,
+			Type:  settingType,
+		}
+		return models.DB.Create(&setting).Error
+	} else {
+		// 如果存在，更新值
+		setting.Value = value
+		if settingType != "" {
+			setting.Type = settingType
+		}
+		return models.DB.Save(&setting).Error
+	}
+}

--- a/server/models/database.go
+++ b/server/models/database.go
@@ -38,6 +38,7 @@ func InitDB() {
 		&KPIEvaluation{},
 		&KPIScore{},
 		&EvaluationComment{},
+		&SystemSetting{},
 	)
 	if err != nil {
 		log.Fatal("数据库迁移失败:", err)
@@ -125,6 +126,15 @@ func CreateTestData() {
 
 	for _, item := range items {
 		DB.Create(&item)
+	}
+
+	// 创建默认系统设置
+	settings := []SystemSetting{
+		{Key: "allow_registration", Value: "true", Type: "boolean"},
+	}
+
+	for _, setting := range settings {
+		DB.Create(&setting)
 	}
 
 	log.Println("测试数据创建完成")

--- a/server/models/models.go
+++ b/server/models/models.go
@@ -118,3 +118,13 @@ type EvaluationComment struct {
 	Evaluation KPIEvaluation `json:"evaluation,omitempty" gorm:"foreignKey:EvaluationID"`
 	User       Employee      `json:"user,omitempty" gorm:"foreignKey:UserID"`
 }
+
+// 系统设置模型
+type SystemSetting struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	Key       string    `json:"key" gorm:"unique;not null"`
+	Value     string    `json:"value" gorm:"not null"`
+	Type      string    `json:"type" gorm:"default:string"` // string, boolean, number, json
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/server/routes/routes.go
+++ b/server/routes/routes.go
@@ -126,5 +126,12 @@ func SetupRoutes(r *gin.RouterGroup) {
 		{
 			downloadRoutes.GET("/exports/:filename", handlers.DownloadFile)
 		}
+
+		// 系统设置（HR权限）
+		settingsRoutes := protected.Group("/settings")
+		{
+			settingsRoutes.GET("", handlers.GetSystemSettings) // 所有用户可以读取设置
+			settingsRoutes.PUT("", handlers.RoleMiddleware("hr"), handlers.UpdateSystemSettings) // 只有HR可以修改设置
+		}
 	}
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Simplify system settings by implementing a persistent 'allow registration' toggle and a logout feature.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The existing settings page contained numerous non-functional configuration options. This PR streamlines the settings to include only the 'allow registration' control, which is now fully integrated with backend persistence and affects the user registration flow, alongside a practical logout button.